### PR TITLE
alpacastore: cast _cash and _value as floats

### DIFF
--- a/alpaca_backtrader_api/alpacastore.py
+++ b/alpaca_backtrader_api/alpacastore.py
@@ -469,8 +469,8 @@ class AlpacaStore(with_metaclass(MetaSingleton, object)):
                 self.put_notification(accinfo.message)
                 continue
             try:
-                self._cash = accinfo.cash
-                self._value = accinfo.portfolio_value
+                self._cash = float(accinfo.cash)
+                self._value = float(accinfo.portfolio_value)
             except KeyError:
                 pass
 


### PR DESCRIPTION
to fix:
File "C:\Python36\lib\site-packages\backtrader\sizers\percents_sizer.py", line 49, in _getsizing
	size = cash / data.close[0] * (self.params.percents / 100)
TypeError: unsupported operand type(s) for /: 'str' and 'float'