### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ $ pip3 install alpaca-backtrader-api
 ```
 
 ## Example
+#### This example only works if you have a funded brokerage account or another means of accessing Polygon data.
 
 In order to call Alpaca's trade API, you need to obtain API key pairs.
 Replace <key_id> and <secret_key> with what you get from the web console.

--- a/alpaca_backtrader_api/alpacastore.py
+++ b/alpaca_backtrader_api/alpacastore.py
@@ -208,7 +208,10 @@ class AlpacaStore(with_metaclass(MetaSingleton, object)):
         else:
             self._oenv = self._ENVLIVE
             self.p.base_url = self._ENV_LIVE_URL
-        self.oapi = API(self.p.key_id, self.p.secret_key, self.p.base_url, self.p.api_version)
+        self.oapi = API(self.p.key_id,
+                        self.p.secret_key,
+                        self.p.base_url,
+                        self.p.api_version)
 
         self._cash = 0.0
         self._value = 0.0


### PR DESCRIPTION
add this to the example code: `This example only works if you have a funded brokerage account or another means of accessing Polygon data.`
to make it clear that you cannot execute it with a non funded brokerage account API key