### PR TITLE
Fix the alpaca broker.positions data

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ pip3 install alpaca-backtrader-api
 
 #### These examples only work if you have a funded brokerage account or another means of accessing Polygon data.
 
-you can find example strategies in the [samples](/samples) folder. 
+you can find example strategies in the [samples](https://github.com/alpacahq/alpaca-backtrader-api/tree/master/sample) folder. 
 
 remember to add you credentials.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ $ pip3 install alpaca-backtrader-api
 ```
 
 ## Example
+#### This example only works if you have a funded brokerage account or another means of accessing Polygon data.
 
 In order to call Alpaca's trade API, you need to obtain API key pairs.
 Replace <key_id> and <secret_key> with what you get from the web console.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,16 @@ $ pip3 install alpaca-backtrader-api
 ```
 
 ## Example
-#### This example only works if you have a funded brokerage account or another means of accessing Polygon data.
+
+#### These examples only work if you have a funded brokerage account or another means of accessing Polygon data.
+
+you can find example strategies in the [samples](/samples) folder. 
+
+remember to add you credentials.
+
+you can toggle between backtesting and paper trading by changing `ALPACA_PAPER`
+
+#### a strategy looks like this:
 
 In order to call Alpaca's trade API, you need to obtain API key pairs.
 Replace <key_id> and <secret_key> with what you get from the web console.

--- a/alpaca_backtrader_api/__init__.py
+++ b/alpaca_backtrader_api/__init__.py
@@ -5,4 +5,4 @@ from .alpacadata import AlpacaData
 __all__ = [
     'AlpacaStore', 'AlpacaBroker', 'AlpacaData',
 ]
-__version__ = '0.3'
+__version__ = '0.4'

--- a/alpaca_backtrader_api/__init__.py
+++ b/alpaca_backtrader_api/__init__.py
@@ -5,4 +5,4 @@ from .alpacadata import AlpacaData
 __all__ = [
     'AlpacaStore', 'AlpacaBroker', 'AlpacaData',
 ]
-__version__ = '0.4'
+__version__ = '0.5'

--- a/alpaca_backtrader_api/alpacabroker.py
+++ b/alpaca_backtrader_api/alpacabroker.py
@@ -68,7 +68,6 @@ class AlpacaBroker(with_metaclass(MetaAlpacaBroker, BrokerBase)):
         self.startingvalue = self.value = 0.0        
         self.addcommissioninfo(self, AlpacaCommInfo(mult=1.0, stocklike=False))
 
-
     def update_positions(self):
         """
         this method syncs the Alpaca real broker positions and the Backtrader
@@ -151,7 +150,9 @@ class AlpacaBroker(with_metaclass(MetaAlpacaBroker, BrokerBase)):
         return cash
 
     def getvalue(self, datas=None):
-        self.value = self.o.get_value()
+        # don't use self.o.get_value(). it takes time for local store to get
+        # update from broker.
+        self.value = self.o.oapi.get_account().portfolio_value
         return self.value
 
     def getposition(self, data, clone=True):

--- a/alpaca_backtrader_api/alpacabroker.py
+++ b/alpaca_backtrader_api/alpacabroker.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import collections
 
 from backtrader import BrokerBase, Order, BuyOrder, SellOrder
-from backtrader.utils.py3 import with_metaclass
+from backtrader.utils.py3 import with_metaclass, iteritems
 from backtrader.comminfo import CommInfoBase
 from backtrader.position import Position
 
@@ -61,8 +61,30 @@ class AlpacaBroker(with_metaclass(MetaAlpacaBroker, BrokerBase)):
 
         self.startingcash = self.cash = 0.0
         self.startingvalue = self.value = 0.0
-        self.positions = collections.defaultdict(Position)
+        self.positions = self.update_positions()
         self.addcommissioninfo(self, AlpacaCommInfo(mult=1.0, stocklike=False))
+
+
+    def update_positions(self):
+        positions = collections.defaultdict(Position)
+        if self.p.use_positions:
+            broker_positions = self.o.oapi.list_positions()
+            broker_positions_symbols = [p.symbol for p in broker_positions]
+            broker_positions_mapped_by_symbol = \
+                {p.symbol: p for p in broker_positions}
+
+            for name, data in iteritems(self.cerebro.datasbyname):
+                if name in broker_positions_symbols:
+
+                    is_sell = broker_positions_mapped_by_symbol[name].side ==\
+                              'short'
+                    size = broker_positions_mapped_by_symbol[name].qty
+                    if is_sell:
+                        size = -size
+                    positions[data] = Position(
+                        size,
+                        broker_positions_mapped_by_symbol[name].avg_entry_price)
+        return positions
 
     def start(self):
         super(AlpacaBroker, self).start()
@@ -70,17 +92,6 @@ class AlpacaBroker(with_metaclass(MetaAlpacaBroker, BrokerBase)):
         self.o.start(broker=self)
         self.startingcash = self.cash = self.o.get_cash()
         self.startingvalue = self.value = self.o.get_value()
-
-        if self.p.use_positions:
-            for p in self.o.get_positions():
-                # print('position for instrument:', p['symbol'])
-                # print('position for instrument:', p.symbol)
-                is_sell = p.side == 'short'
-                size = float(p.qty)
-                if is_sell:
-                    size = -size
-                price = float(p.avg_entry_price)
-                self.positions[p.symbol] = Position(size, price)
 
     def data_started(self, data):
         pos = self.getposition(data)
@@ -131,8 +142,7 @@ class AlpacaBroker(with_metaclass(MetaAlpacaBroker, BrokerBase)):
         return self.value
 
     def getposition(self, data, clone=True):
-        # return self.o.getposition(data._dataname, clone=clone)
-        pos = self.positions[data._dataname]
+        pos = self.positions[data]
         if clone:
             pos = pos.clone()
 
@@ -318,6 +328,7 @@ class AlpacaBroker(with_metaclass(MetaAlpacaBroker, BrokerBase)):
         return self.o.order_cancel(order)
 
     def notify(self, order):
+        self.positions = self.update_positions()
         self.notifs.append(order.clone())
 
     def get_notification(self):

--- a/alpaca_backtrader_api/alpacabroker.py
+++ b/alpaca_backtrader_api/alpacabroker.py
@@ -65,8 +65,7 @@ class AlpacaBroker(with_metaclass(MetaAlpacaBroker, BrokerBase)):
         self.brackets = dict()  # confirmed brackets
 
         self.startingcash = self.cash = 0.0
-        self.startingvalue = self.value = 0.0
-        self.positions = self.update_positions()
+        self.startingvalue = self.value = 0.0        
         self.addcommissioninfo(self, AlpacaCommInfo(mult=1.0, stocklike=False))
 
 
@@ -97,6 +96,7 @@ class AlpacaBroker(with_metaclass(MetaAlpacaBroker, BrokerBase)):
         self.o.start(broker=self)
         self.startingcash = self.cash = self.o.get_cash()
         self.startingvalue = self.value = self.o.get_value()
+        self.positions = self.update_positions()
 
     def data_started(self, data):
         pos = self.getposition(data)

--- a/alpaca_backtrader_api/alpacabroker.py
+++ b/alpaca_backtrader_api/alpacabroker.py
@@ -70,6 +70,14 @@ class AlpacaBroker(with_metaclass(MetaAlpacaBroker, BrokerBase)):
 
 
     def update_positions(self):
+        """
+        this method syncs the Alpaca real broker positions and the Backtrader
+        broker instance. the positions is defined in BrokerBase (in getposition)
+        and used in bbroker (the backtrader broker instance) with Data as the 
+        key. so we do the same here. we create a defaultdict of Position() with 
+        data as the key.
+        :return: collections.defaultdict ({data: Position})
+        """
         positions = collections.defaultdict(Position)
         if self.p.use_positions:
             broker_positions = self.o.oapi.list_positions()

--- a/alpaca_backtrader_api/alpacabroker.py
+++ b/alpaca_backtrader_api/alpacabroker.py
@@ -17,21 +17,26 @@ class AlpacaCommInfo(CommInfoBase):
         return abs(size) * price
 
     def getoperationcost(self, size, price):
-        '''Returns the needed amount of cash an operation would cost'''
+        """
+        Returns the needed amount of cash an operation would cost
+        """
         # Same reasoning as above
         return abs(size) * price
 
 
 class MetaAlpacaBroker(BrokerBase.__class__):
     def __init__(cls, name, bases, dct):
-        '''Class has already been created ... register'''
+        """
+        Class has already been created ... register
+        """
         # Initialize the class
         super(MetaAlpacaBroker, cls).__init__(name, bases, dct)
         alpacastore.AlpacaStore.BrokerCls = cls
 
 
 class AlpacaBroker(with_metaclass(MetaAlpacaBroker, BrokerBase)):
-    '''Broker implementation for Alpaca.
+    """
+    Broker implementation for Alpaca.
 
     This class maps the orders/positions from Alpaca to the
     internal API of ``backtrader``.
@@ -43,7 +48,7 @@ class AlpacaBroker(with_metaclass(MetaAlpacaBroker, BrokerBase)):
 
         Set to ``False`` during instantiation to disregard any existing
         position
-    '''
+    """
     params = (
         ('use_positions', True),
     )

--- a/alpaca_backtrader_api/alpacadata.py
+++ b/alpaca_backtrader_api/alpacadata.py
@@ -12,7 +12,9 @@ from alpaca_backtrader_api import alpacastore
 
 class MetaAlpacaData(DataBase.__class__):
     def __init__(cls, name, bases, dct):
-        '''Class has already been created ... register'''
+        """
+        Class has already been created ... register
+        """
         # Initialize the class
         super(MetaAlpacaData, cls).__init__(name, bases, dct)
 
@@ -21,7 +23,8 @@ class MetaAlpacaData(DataBase.__class__):
 
 
 class AlpacaData(with_metaclass(MetaAlpacaData, DataBase)):
-    '''Alpaca Data Feed.
+    """
+    Alpaca Data Feed.
 
     Params:
 
@@ -115,7 +118,7 @@ class AlpacaData(with_metaclass(MetaAlpacaData, DataBase)):
         (TimeFrame.Months, 1): 'M',
 
     Any other combination will be rejected
-    '''
+    """
     params = (
         ('qcheck', 0.5),
         ('historical', False),  # do backfilling at the start
@@ -142,8 +145,10 @@ class AlpacaData(with_metaclass(MetaAlpacaData, DataBase)):
         return self._TOFFSET
 
     def islive(self):
-        '''Returns ``True`` to notify ``Cerebro`` that preloading and runonce
-        should be deactivated'''
+        """
+        Returns ``True`` to notify ``Cerebro`` that preloading and runonce
+        should be deactivated
+        """
         return True
 
     def __init__(self, **kwargs):
@@ -152,14 +157,18 @@ class AlpacaData(with_metaclass(MetaAlpacaData, DataBase)):
         self.do_qcheck(True, 0)
 
     def setenvironment(self, env):
-        '''Receives an environment (cerebro) and passes it over to the store it
-        belongs to'''
+        """
+        Receives an environment (cerebro) and passes it over to the store it
+        belongs to
+        """
         super(AlpacaData, self).setenvironment(env)
         env.addstore(self.o)
 
     def start(self):
-        '''Starts the Alpaca connecction and gets the real contract and
-        contractdetails if it exists'''
+        """
+        Starts the Alpaca connecction and gets the real contract and
+        contractdetails if it exists
+        """
         super(AlpacaData, self).start()
 
         # Create attributes as soon as possible
@@ -229,7 +238,9 @@ class AlpacaData(with_metaclass(MetaAlpacaData, DataBase)):
         return True  # no return before - implicit continue
 
     def stop(self):
-        '''Stops and tells the store to stop'''
+        """
+        Stops and tells the store to stop
+        """
         super(AlpacaData, self).stop()
         self.o.stop()
 

--- a/alpaca_backtrader_api/alpacastore.py
+++ b/alpaca_backtrader_api/alpacastore.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import collections
 from datetime import datetime, timedelta
-import dateutil
+from dateutil.parser import parse as date_parse
 import time as _time
 import threading
 import asyncio
@@ -340,6 +340,16 @@ class AlpacaStore(with_metaclass(MetaSingleton, object)):
         t.start()
         return q
 
+    @staticmethod
+    def iso_date(date_str):
+        """
+        this method will make sure that dates are formatted properly
+        as with isoformat
+        :param date_str:
+        :return: YYYY-MM-DD date formatted
+        """
+        return date_parse(date_str).date().isoformat()
+
     def _t_candles(self, dataname, dtbegin, dtend, timeframe, compression,
                    candleFormat, includeFirst, q):
 
@@ -369,11 +379,13 @@ class AlpacaStore(with_metaclass(MetaSingleton, object)):
                 start_dt = None
                 if dtkwargs['start']:
                     start_dt = dtkwargs['start'].isoformat()
-                response = self.oapi.polygon.historic_agg_v2(dataname,
-                                                             compression,
-                                                             granularity,
-                                                             _from=dateutil.parser.parse(start_dt).date().isoformat(),
-                                                             to=dateutil.parser.parse(end_dt).date().isoformat())
+                response = \
+                    self.oapi.polygon.historic_agg_v2(
+                        dataname,
+                        compression,
+                        granularity,
+                        _from=self.iso_date(start_dt),
+                        to=self.iso_date(end_dt))
             except AlpacaError as e:
                 print(str(e))
                 q.put(e.error_response)

--- a/alpaca_backtrader_api/alpacastore.py
+++ b/alpaca_backtrader_api/alpacastore.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import collections
 from datetime import datetime, timedelta
+import dateutil
 import time as _time
 import threading
 import asyncio
@@ -371,8 +372,8 @@ class AlpacaStore(with_metaclass(MetaSingleton, object)):
                 response = self.oapi.polygon.historic_agg_v2(dataname,
                                                              compression,
                                                              granularity,
-                                                             _from=start_dt,
-                                                             to=end_dt)
+                                                             _from=dateutil.parser.parse(start_dt).date().isoformat(),
+                                                             to=dateutil.parser.parse(end_dt).date().isoformat())
             except AlpacaError as e:
                 print(str(e))
                 q.put(e.error_response)

--- a/alpaca_backtrader_api/alpacastore.py
+++ b/alpaca_backtrader_api/alpacastore.py
@@ -324,7 +324,8 @@ class AlpacaStore(with_metaclass(MetaSingleton, object)):
         :param dtbegin: datetime start
         :param dtend: datetime end
         :param timeframe: bt.TimeFrame
-        :param compression: distance between samples. e.g if 1 => get sample every day. if 3 => get sample every 3 days
+        :param compression: distance between samples. e.g if 1 =>
+                 get sample every day. if 3 => get sample every 3 days
         :param candleFormat: (bidask, midpoint, trades)
         :param includeFirst:
         :return:
@@ -406,7 +407,10 @@ class AlpacaStore(with_metaclass(MetaSingleton, object)):
                                       'low': 'min',
                                       'close': 'last',
                                       'volume': 'sum'})
-        cdl = cdl.loc[dtbegin.replace(tzinfo=pytz.timezone(NY)):dtend.replace(tzinfo=pytz.timezone(NY))].dropna(subset=['high'])
+        cdl = cdl.loc[
+              dtbegin.replace(tzinfo=pytz.timezone(NY)):
+              dtend.replace(tzinfo=pytz.timezone(NY))
+              ].dropna(subset=['high'])
         records = cdl.reset_index().to_dict('records')
         for r in records:
             r['time'] = r['timestamp']

--- a/alpaca_backtrader_api/alpacastore.py
+++ b/alpaca_backtrader_api/alpacastore.py
@@ -13,6 +13,7 @@ import requests
 import pandas as pd
 
 import backtrader as bt
+from alpaca_trade_api.polygon.entity import NY
 from backtrader.metabase import MetaParams
 from backtrader.utils.py3 import queue, with_metaclass
 
@@ -402,7 +403,7 @@ class AlpacaStore(with_metaclass(MetaSingleton, object)):
                                       'low': 'min',
                                       'close': 'last',
                                       'volume': 'sum'})
-        cdl = cdl.loc[dtbegin.replace(tzinfo=pytz.UTC):dtend.replace(tzinfo=pytz.UTC)].dropna(subset=['high'])
+        cdl = cdl.loc[dtbegin.replace(tzinfo=pytz.timezone(NY)):dtend.replace(tzinfo=pytz.timezone(NY))].dropna(subset=['high'])
         records = cdl.reset_index().to_dict('records')
         # field = 'day' if 'd' in granularity else 'timestamp'
         field = 'timestamp'

--- a/alpaca_backtrader_api/alpacastore.py
+++ b/alpaca_backtrader_api/alpacastore.py
@@ -210,7 +210,10 @@ class AlpacaStore(with_metaclass(MetaSingleton, object)):
         else:
             self._oenv = self._ENVLIVE
             self.p.base_url = self._ENV_LIVE_URL
-        self.oapi = API(self.p.key_id, self.p.secret_key, self.p.base_url, self.p.api_version)
+        self.oapi = API(self.p.key_id,
+                        self.p.secret_key,
+                        self.p.base_url,
+                        self.p.api_version)
 
         self._cash = 0.0
         self._value = 0.0
@@ -405,10 +408,8 @@ class AlpacaStore(with_metaclass(MetaSingleton, object)):
                                       'volume': 'sum'})
         cdl = cdl.loc[dtbegin.replace(tzinfo=pytz.timezone(NY)):dtend.replace(tzinfo=pytz.timezone(NY))].dropna(subset=['high'])
         records = cdl.reset_index().to_dict('records')
-        # field = 'day' if 'd' in granularity else 'timestamp'
-        field = 'timestamp'
         for r in records:
-            r['time'] = r[field]
+            r['time'] = r['timestamp']
             q.put(r)
         q.put({})  # end of transmission
 

--- a/sample/github_example_strategy.py
+++ b/sample/github_example_strategy.py
@@ -1,0 +1,47 @@
+# This is the example code from the repo's README
+import alpaca_backtrader_api
+import backtrader as bt
+from datetime import datetime
+
+# Your credentials here
+ALPACA_API_KEY = "<key_id>"
+ALPACA_SECRET_KEY = "<secret_key>"
+# change to True if you want to do live paper trading with Alpaca Broker.
+#  False will do a back test
+ALPACA_PAPER = False
+
+
+class SmaCross(bt.SignalStrategy):
+  def __init__(self):
+    sma1, sma2 = bt.ind.SMA(period=10), bt.ind.SMA(period=30)
+    crossover = bt.ind.CrossOver(sma1, sma2)
+    self.signal_add(bt.SIGNAL_LONG, crossover)
+
+
+if __name__ == '__main__':
+    cerebro = bt.Cerebro()
+    cerebro.addstrategy(SmaCross)
+
+store = alpaca_backtrader_api.AlpacaStore(
+    key_id=ALPACA_API_KEY,
+    secret_key=ALPACA_SECRET_KEY,
+    paper=True
+)
+
+DataFactory = store.getdata  # or use alpaca_backtrader_api.AlpacaData
+if ALPACA_PAPER:
+    data0 = DataFactory(dataname='AAPL',
+                        historical=False,
+                        timeframe=bt.TimeFrame.Days)
+    cerebro.adddata(data0)
+    broker = store.getbroker()  # or just alpaca_backtrader_api.AlpacaBroker()
+    cerebro.setbroker(broker)
+else:
+    data0 = DataFactory(dataname='AAPL', historical=True, fromdate=datetime(
+        2015, 1, 1), timeframe=bt.TimeFrame.Days)
+cerebro.adddata(data0)
+
+print('Starting Portfolio Value: %.2f' % cerebro.broker.getvalue())
+cerebro.run()
+print('Final Portfolio Value: %.2f' % cerebro.broker.getvalue())
+cerebro.plot()

--- a/sample/multiple_data_strategy.py
+++ b/sample/multiple_data_strategy.py
@@ -1,0 +1,102 @@
+import alpaca_backtrader_api
+import backtrader as bt
+from datetime import datetime
+
+# Your credentials here
+ALPACA_API_KEY = "<key_id>"
+ALPACA_SECRET_KEY = "<secret_key>"
+# change to True if you want to do live paper trading with Alpaca Broker.
+#  False will do a back test
+ALPACA_PAPER = False
+
+
+class SmaCross1(bt.Strategy):
+    # list of parameters which are configurable for the strategy
+    params = dict(
+        pfast=10,  # period for the fast moving average
+        pslow=30   # period for the slow moving average
+    )
+
+    def log(self, txt, dt=None):
+        dt = dt or self.data.datetime[0]
+        dt = bt.num2date(dt)
+        print('%s, %s' % (dt.isoformat(), txt))
+
+    def notify_trade(self, trade):
+        self.log("placing trade for {}. target size: {}".format(
+            trade.getdataname(),
+            trade.size))
+
+    def notify_order(self, order):
+        pass
+
+    def stop(self):
+        print('==================================================')
+        print('Starting Value - %.2f' % self.broker.startingcash)
+        print('Ending   Value - %.2f' % self.broker.getvalue())
+        print('==================================================')
+
+    def __init__(self):
+        sma1 = bt.ind.SMA(self.data0, period=self.p.pfast)
+        sma2 = bt.ind.SMA(self.data0, period=self.p.pslow)
+        self.crossover0 = bt.ind.CrossOver(sma1, sma2)
+
+        sma1 = bt.ind.SMA(self.data1, period=self.p.pfast)
+        sma2 = bt.ind.SMA(self.data1, period=self.p.pslow)
+        self.crossover1 = bt.ind.CrossOver(sma1, sma2)
+
+
+
+    def next(self):
+        # if fast crosses slow to the upside
+        if not self.positionsbyname["AAPL"].size and self.crossover0 > 0:
+            self.buy(data=data0, size=5)  # enter long
+
+        if not self.positionsbyname["GOOG"].size and self.crossover1 > 0:
+            self.buy(data=data1, size=5)  # enter long
+
+        # in the market & cross to the downside
+        if self.positionsbyname["AAPL"].size and self.crossover0 <= 0:
+            self.close(data=data0)  # close long position
+        # in the market & cross to the downside
+        if self.positionsbyname["GOOG"].size and self.crossover1 <= 0:
+            self.close(data=data1)  # close long position
+
+
+if __name__ == '__main__':
+    cerebro = bt.Cerebro()
+    cerebro.addstrategy(SmaCross1)
+
+    store = alpaca_backtrader_api.AlpacaStore(
+        key_id=ALPACA_API_KEY,
+        secret_key=ALPACA_SECRET_KEY,
+        paper=True
+    )
+
+    DataFactory = store.getdata  # or use alpaca_backtrader_api.AlpacaData
+    if ALPACA_PAPER:
+        data0 = DataFactory(dataname='AAPL',
+                            historical=False,
+                            timeframe=bt.TimeFrame.Days)
+        data1 = DataFactory(dataname='GOOG',
+                            historical=False,
+                            timeframe=bt.TimeFrame.Days)
+        # or just alpaca_backtrader_api.AlpacaBroker()
+        broker = store.getbroker()
+        cerebro.setbroker(broker)
+    else:
+        data0 = DataFactory(dataname='AAPL', historical=True, fromdate=datetime(
+            2015, 1, 1), timeframe=bt.TimeFrame.Days)
+        data1 = DataFactory(dataname='GOOG', historical=True, fromdate=datetime(
+            2015, 1, 1), timeframe=bt.TimeFrame.Days)
+    cerebro.adddata(data0)
+    cerebro.adddata(data1)
+
+    if not ALPACA_PAPER:
+        # backtrader broker set initial simulated cash
+        cerebro.broker.setcash(100000.0)
+
+    print('Starting Portfolio Value: %.2f' % cerebro.broker.getvalue())
+    cerebro.run()
+    print('Final Portfolio Value: %.2f' % cerebro.broker.getvalue())
+    cerebro.plot()

--- a/sample/multiple_indicator_strategy.py
+++ b/sample/multiple_indicator_strategy.py
@@ -1,0 +1,98 @@
+import alpaca_backtrader_api
+import backtrader as bt
+from datetime import datetime
+
+# Your credentials here
+ALPACA_API_KEY = "<key_id>"
+ALPACA_SECRET_KEY = "<secret_key>"
+# change to True if you want to do live paper trading with Alpaca Broker.
+#  False will do a back test
+ALPACA_PAPER = False
+
+
+class SmaCross1(bt.Strategy):
+    # list of parameters which are configurable for the strategy
+    params = dict(
+        pfast=10,  # period for the fast moving average
+        pslow=30,   # period for the slow moving average
+        rsi_per=14,
+        rsi_upper=65.0,
+        rsi_lower=35.0,
+        rsi_out=50.0,
+        warmup=35
+    )
+
+    def log(self, txt, dt=None):
+        dt = dt or self.data.datetime[0]
+        dt = bt.num2date(dt)
+        print('%s, %s' % (dt.isoformat(), txt))
+
+    def notify_trade(self, trade):
+        self.log("placing trade for {}. target size: {}".format(
+            trade.getdataname(),
+            trade.size))
+
+    def notify_order(self, order):
+        pass
+
+    def stop(self):
+        print('==================================================')
+        print('Starting Value - %.2f' % self.broker.startingcash)
+        print('Ending   Value - %.2f' % self.broker.getvalue())
+        print('==================================================')
+
+    def __init__(self):
+        sma1 = bt.ind.SMA(self.data0, period=self.p.pfast)
+        sma2 = bt.ind.SMA(self.data0, period=self.p.pslow)
+        self.crossover = bt.ind.CrossOver(sma1, sma2)
+
+        rsi = bt.indicators.RSI(period=self.p.rsi_per,
+                                upperband=self.p.rsi_upper,
+                                lowerband=self.p.rsi_lower)
+
+        self.crossdown = bt.ind.CrossDown(rsi, self.p.rsi_upper)
+        self.crossup = bt.ind.CrossUp(rsi, self.p.rsi_lower)
+
+    def next(self):
+        # if fast crosses slow to the upside
+        if not self.positionsbyname["AAPL"].size:
+            if self.crossover > 0 or self.crossup > 0:
+                self.buy(data=data0, size=5)  # enter long
+
+        # in the market & cross to the downside
+        if self.positionsbyname["AAPL"].size:
+            if self.crossover <= 0 or self.crossdown < 0:
+                self.close(data=data0)  # close long position
+
+
+if __name__ == '__main__':
+    cerebro = bt.Cerebro()
+    cerebro.addstrategy(SmaCross1)
+
+    store = alpaca_backtrader_api.AlpacaStore(
+        key_id=ALPACA_API_KEY,
+        secret_key=ALPACA_SECRET_KEY,
+        paper=True
+    )
+
+    DataFactory = store.getdata  # or use alpaca_backtrader_api.AlpacaData
+    if ALPACA_PAPER:
+        data0 = DataFactory(dataname='AAPL',
+                            historical=False,
+                            timeframe=bt.TimeFrame.Days)
+        # or just alpaca_backtrader_api.AlpacaBroker()
+        broker = store.getbroker()
+        cerebro.setbroker(broker)
+    else:
+        data0 = DataFactory(dataname='AAPL', historical=True, fromdate=datetime(
+            2015, 1, 1), timeframe=bt.TimeFrame.Days)
+    cerebro.adddata(data0)
+
+    if not ALPACA_PAPER:
+        # backtrader broker set initial simulated cash
+        cerebro.broker.setcash(100000.0)
+
+    print('Starting Portfolio Value: %.2f' % cerebro.broker.getvalue())
+    cerebro.run()
+    print('Final Portfolio Value: %.2f' % cerebro.broker.getvalue())
+    cerebro.plot()

--- a/sample/sma_cross_over_strategy.py
+++ b/sample/sma_cross_over_strategy.py
@@ -1,0 +1,84 @@
+import alpaca_backtrader_api
+import backtrader as bt
+from datetime import datetime
+
+# Your credentials here
+ALPACA_API_KEY = "<key_id>"
+ALPACA_SECRET_KEY = "<secret_key>"
+# change to True if you want to do live paper trading with Alpaca Broker.
+#  False will do a back test
+ALPACA_PAPER = False
+
+
+class SmaCross1(bt.Strategy):
+    # list of parameters which are configurable for the strategy
+    params = dict(
+        pfast=10,  # period for the fast moving average
+        pslow=30   # period for the slow moving average
+    )
+
+    def log(self, txt, dt=None):
+        dt = dt or self.data.datetime[0]
+        dt = bt.num2date(dt)
+        print('%s, %s' % (dt.isoformat(), txt))
+
+    def notify_trade(self, trade):
+        self.log("placing trade for {}. target size: {}".format(
+            trade.getdataname(),
+            trade.size))
+
+    def notify_order(self, order):
+        pass
+
+    def stop(self):
+        print('==================================================')
+        print('Starting Value - %.2f' % self.broker.startingcash)
+        print('Ending   Value - %.2f' % self.broker.getvalue())
+        print('==================================================')
+
+    def __init__(self):
+        sma1 = bt.ind.SMA(self.data0, period=self.p.pfast)
+        sma2 = bt.ind.SMA(self.data0, period=self.p.pslow)
+        self.crossover0 = bt.ind.CrossOver(sma1, sma2)
+
+    def next(self):
+        # if fast crosses slow to the upside
+        if not self.positionsbyname["AAPL"].size and self.crossover0 > 0:
+            self.buy(data=data0, size=5)  # enter long
+
+        # in the market & cross to the downside
+        if self.positionsbyname["AAPL"].size and self.crossover0 <= 0:
+            self.close(data=data0)  # close long position
+
+
+if __name__ == '__main__':
+    cerebro = bt.Cerebro()
+    cerebro.addstrategy(SmaCross1)
+
+    store = alpaca_backtrader_api.AlpacaStore(
+        key_id=ALPACA_API_KEY,
+        secret_key=ALPACA_SECRET_KEY,
+        paper=True
+    )
+
+    DataFactory = store.getdata  # or use alpaca_backtrader_api.AlpacaData
+    if ALPACA_PAPER:
+        data0 = DataFactory(dataname='AAPL',
+                            historical=False,
+                            timeframe=bt.TimeFrame.Days)
+        # or just alpaca_backtrader_api.AlpacaBroker()
+        broker = store.getbroker()
+        cerebro.setbroker(broker)
+    else:
+        data0 = DataFactory(dataname='AAPL', historical=True, fromdate=datetime(
+            2015, 1, 1), timeframe=bt.TimeFrame.Days)
+    cerebro.adddata(data0)
+
+    if not ALPACA_PAPER:
+        # backtrader broker set initial simulated cash
+        cerebro.broker.setcash(100000.0)
+
+    print('Starting Portfolio Value: %.2f' % cerebro.broker.getvalue())
+    cerebro.run()
+    print('Final Portfolio Value: %.2f' % cerebro.broker.getvalue())
+    cerebro.plot()


### PR DESCRIPTION
### broker.positions
1. it should never return empty object (if I call broker.getposition('TSLA') but I don't have a TSLA position I will still get Position() object without real broker data inside
2. positions's key is data as defined in the backtrader api. it was stored by name (e.g TSLA)
3. fix other methods like getposition(), getpositionbyname(), now works properly after changeing key to data
4. update the data when new positions are opened ( not only at the beginning )

### thread excpetion protection
  order handling in alpacastore for receive order thread. make sure thread doesn't crash and stop handling orders. 

### pep8
cleanups and documentation 