### PR TITLE
Add support for backfill_from using static data

### DIFF
--- a/alpaca_backtrader_api/alpacadata.py
+++ b/alpaca_backtrader_api/alpacadata.py
@@ -195,6 +195,7 @@ class AlpacaData(with_metaclass(MetaAlpacaData, DataBase)):
 
         if self.p.backfill_from is not None:
             self._state = self._ST_FROM
+            self.p.backfill_from.setenvironment(self._env)
             self.p.backfill_from._start()
         else:
             self._start_finish()


### PR DESCRIPTION
This fixes the error 
```
Traceback (most recent call last):
  File "/Users/jbales/Personal-Repos/algorithmic-trading/main.py", line 114, in <module>
    main()
  File "/Users/jbales/Personal-Repos/algorithmic-trading/main.py", line 74, in main
    cerebro.run()
  File "/usr/local/lib/python3.7/site-packages/backtrader/cerebro.py", line 1127, in run
    runstrat = self.runstrategies(iterstrat)
  File "/usr/local/lib/python3.7/site-packages/backtrader/cerebro.py", line 1210, in runstrategies
    data._start()
  File "/usr/local/lib/python3.7/site-packages/backtrader/feed.py", line 203, in _start
    self.start()
  File "/usr/local/lib/python3.7/site-packages/alpaca_backtrader_api/alpacadata.py", line 198, in start
    self.p.backfill_from._start()
  File "/usr/local/lib/python3.7/site-packages/backtrader/feed.py", line 206, in _start
    self._start_finish()
  File "/usr/local/lib/python3.7/site-packages/backtrader/feed.py", line 196, in _start_finish
    self._calendar = self._env._tradingcal
  File "/usr/local/lib/python3.7/site-packages/backtrader/lineseries.py", line 461, in __getattr__
    return getattr(self.lines, name)
AttributeError: 'Lines_LineSeries_DataSeries_OHLC_OHLCDateTime_Abst' object has no attribute '_env'
```

The solution is already implemented in `IBData` here [/backtrader/feeds/ibdata.py](https://github.com/mementum/backtrader/blob/master/backtrader/feeds/ibdata.py#L363)

This allows for backfilling in a batch with something like Alpha Vantage data then proceeding with live alpaca/polygon data. 

Reference material 
[Backtrader Community Forums](https://community.backtrader.com/topic/26/example-of-adding-live-data-to-static-in-strategy/8)
[Backtrader IBData live data docs](https://www.backtrader.com/docu/dataautoref/#ibdata)