### PR TITLE
Notify user when bracket orders are executed

### DIFF
--- a/alpaca_backtrader_api/alpacastore.py
+++ b/alpaca_backtrader_api/alpacastore.py
@@ -603,7 +603,7 @@ class AlpacaStore(with_metaclass(MetaSingleton, object)):
                 except Exception as e:
                     self.put_notification(e)
                     self.broker._reject(oref)
-                    return
+                    continue
                 try:
                     oid = o.id
                 except Exception:

--- a/alpaca_backtrader_api/alpacastore.py
+++ b/alpaca_backtrader_api/alpacastore.py
@@ -420,11 +420,12 @@ class AlpacaStore(with_metaclass(MetaSingleton, object)):
                     # so get_aggs work nicely for days but not for minutes, and
                     # it is not a documented API. barset on the other hand does
                     # but we need to manipulate it to be able to work with it
-                    # smootly
-                    response = self.oapi.get_barset(dataname,
-                                                    granularity,
-                                                    start=start_dt,
-                                                    end=end_dt)[dataname]._raw
+                    # smoothly and return data the same way polygon does
+                    response = self.oapi.get_barset(
+                        dataname,
+                        granularity,
+                        start=start_dt,
+                        end=end_dt)[dataname]._raw
                     for bar in response:
                         # Aggs are in milliseconds, we multiply by 1000 to
                         # change seconds to ms

--- a/alpaca_backtrader_api/alpacastore.py
+++ b/alpaca_backtrader_api/alpacastore.py
@@ -592,12 +592,11 @@ class AlpacaStore(with_metaclass(MetaSingleton, object)):
     def _t_order_create(self):
         while True:
             try:
-                # if self.q_ordercreate.empty():
-                #     continue
+                if self.q_ordercreate.empty():
+                    continue
                 msg = self.q_ordercreate.get()
                 if msg is None:
-                    break
-
+                    continue
                 oref, okwargs = msg
                 try:
                     o = self.oapi.submit_order(**okwargs)
@@ -614,7 +613,7 @@ class AlpacaStore(with_metaclass(MetaSingleton, object)):
                         self.put_notification(
                             "General error from the Alpaca server")
                     self.broker._reject(oref)
-                    return
+                    continue
 
                 self._orders[oref] = oid
                 self.broker._submit(oref)


### PR DESCRIPTION
when a bracket order is submitted 3 orders are created. 
e.g 1 buy order, and 2 (stop and limit) sell orders.
we want to make sure that when one of the sell orders are executed, the user is notified and the orders (on the backtrader side) are closed correctly.