### PR TITLE
Fix backfill offset caused by DST

### DIFF
--- a/alpaca_backtrader_api/alpacastore.py
+++ b/alpaca_backtrader_api/alpacastore.py
@@ -464,9 +464,11 @@ class AlpacaStore(with_metaclass(MetaSingleton, object)):
                                       'low': 'min',
                                       'close': 'last',
                                       'volume': 'sum'})
+        # don't use dt.replace. use localize
+        # (https://stackoverflow.com/a/1592837/2739124)
         cdl = cdl.loc[
-              dtbegin.replace(tzinfo=pytz.timezone(NY)):
-              dtend.replace(tzinfo=pytz.timezone(NY))
+              pytz.timezone(NY).localize(dtbegin):
+              pytz.timezone(NY).localize(dtbegin)
               ].dropna(subset=['high'])
         records = cdl.reset_index().to_dict('records')
         for r in records:


### PR DESCRIPTION
When doing a backfill we get the data from alpaca/polygon at the beginning of the execution

then we change the tz info to match the NY tz
due to day light savings, we get an offset by M minutes (changes with the day and year)
how does it influence us?
e.g we need minute data from X to Y, but we get Y - M
M is the offset
so, backtrader doesn't "think" it has all the data it requires to start

we change replace() to localize() which takes care of the issue.