### PR TITLE
Fix alpaca+polygon backfill data fetching

### DIFF
--- a/alpaca_backtrader_api/alpacastore.py
+++ b/alpaca_backtrader_api/alpacastore.py
@@ -379,7 +379,7 @@ class AlpacaStore(with_metaclass(MetaSingleton, object)):
 
         granularity = self.get_granularity(timeframe, compression)
         if granularity is None:
-            e = AlpacaTimeFrameError()
+            e = AlpacaTimeFrameError('')
             q.put(e.error_response)
             return
 

--- a/alpaca_backtrader_api/alpacastore.py
+++ b/alpaca_backtrader_api/alpacastore.py
@@ -488,6 +488,7 @@ class AlpacaStore(with_metaclass(MetaSingleton, object)):
                              granularity,
                              compression):
         """
+        https://alpaca.markets/docs/api-documentation/api-v2/market-data/bars/
         Alpaca API as a limit of 1000 records per api call. meaning, we need to
         do multiple calls to get all the required data if the date range is
         large.

--- a/alpaca_backtrader_api/alpacastore.py
+++ b/alpaca_backtrader_api/alpacastore.py
@@ -609,13 +609,13 @@ class AlpacaStore(with_metaclass(MetaSingleton, object)):
             bar['t'] *= 1000
         response = Aggs({"results": response})
 
+        cdl = response.df
+        if granularity == 'minute':
+            cdl = _clear_out_of_market_hours(cdl)
+            cdl = _drop_early_samples(cdl)
         if compression != 1:
-            cdl = response.df
-            if granularity == 'minute':
-                cdl = _clear_out_of_market_hours(cdl)
-                cdl = _drop_early_samples(cdl)
             response = _resample(cdl)
-            # response = _back_to_aggs(cdl)
+        # response = _back_to_aggs(cdl)
         else:
             response = response.df
         response = response.dropna()

--- a/alpaca_backtrader_api/alpacastore.py
+++ b/alpaca_backtrader_api/alpacastore.py
@@ -513,13 +513,22 @@ class AlpacaStore(with_metaclass(MetaSingleton, object)):
             """
             you could get max 1000 samples from the server. if we need more
             than that we need to do several api calls.
+
+            currently the alpaca api supports also 5Min and 15Min so we could
+            optimize server communication time by addressing timeframes
             """
             got_all = False
             curr = end
             response = []
             while not got_all:
+                if granularity == 'minute' and compression == 5:
+                    timeframe = "5Min"
+                elif granularity == 'minute' and compression == 15:
+                    timeframe = "15Min"
+                else:
+                    timeframe = granularity
                 r = self.oapi.get_barset(dataname,
-                                         granularity,
+                                         timeframe,
                                          limit=1000,
                                          end=curr.isoformat()
                                          )[dataname]
@@ -555,6 +564,7 @@ class AlpacaStore(with_metaclass(MetaSingleton, object)):
             samples returned with certain window size (1 day, 1 minute) user
             may want to work with different window size (5min)
             """
+
             if granularity == 'minute':
                 sample_size = f"{compression}Min"
             else:


### PR DESCRIPTION
we have 3 issues:
1. dates range is too large
 - polygon api doesn't indicate a limit for 1 api call but you can't get six months of data in 1 api call (makes since). data is returned corrupted (patchy data)
 - Alpaca has a limit of 1000 records per api call
2. compression - or not 1 minute/daily bars (e.g 5 minute, 30 minute, 60 minute bars)
 - polygon supports it. alpaca doesn't
3. out of market data
 - both api return out of market hours data. that is of course not what we want when we do these calls

all issues should be addressed