### PR TITLE
Fix broken samples due to missing todate param in backtest mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ if not ALPACA_PAPER:
 
 DataFactory = store.getdata  # or use alpaca_backtrader_api.AlpacaData
 data0 = DataFactory(dataname='AAPL', historical=True, fromdate=datetime(
-    2015, 1, 1), timeframe=bt.TimeFrame.Days)
+    2015, 1, 1), todate=datetime.today(), timeframe=bt.TimeFrame.Days)
 cerebro.adddata(data0)
 
 print('Starting Portfolio Value: %.2f' % cerebro.broker.getvalue())

--- a/sample/strategy_multiple_datas.py
+++ b/sample/strategy_multiple_datas.py
@@ -87,9 +87,9 @@ if __name__ == '__main__':
         cerebro.setbroker(broker)
     else:
         data0 = DataFactory(dataname='AAPL', historical=True, fromdate=datetime(
-            2015, 1, 1), timeframe=bt.TimeFrame.Days)
+            2015, 1, 1), todate=datetime.today(), timeframe=bt.TimeFrame.Days)
         data1 = DataFactory(dataname='GOOG', historical=True, fromdate=datetime(
-            2015, 1, 1), timeframe=bt.TimeFrame.Days)
+            2015, 1, 1), todate=datetime.today(), timeframe=bt.TimeFrame.Days)
     cerebro.adddata(data0)
     cerebro.adddata(data1)
 

--- a/sample/strategy_multiple_indicators.py
+++ b/sample/strategy_multiple_indicators.py
@@ -86,7 +86,7 @@ if __name__ == '__main__':
         cerebro.setbroker(broker)
     else:
         data0 = DataFactory(dataname='AAPL', historical=True, fromdate=datetime(
-            2015, 1, 1), timeframe=bt.TimeFrame.Days)
+            2015, 1, 1), todate=datetime.today(), timeframe=bt.TimeFrame.Days)
     cerebro.adddata(data0)
 
     if not ALPACA_PAPER:

--- a/sample/strategy_readme_sample.py
+++ b/sample/strategy_readme_sample.py
@@ -40,7 +40,7 @@ if __name__ == '__main__':
         cerebro.setbroker(broker)
     else:
         data0 = DataFactory(dataname='AAPL', historical=True, fromdate=datetime(
-            2015, 1, 1), timeframe=bt.TimeFrame.Days)
+            2015, 1, 1), todate=datetime.today(), timeframe=bt.TimeFrame.Days)
     cerebro.adddata(data0)
 
     print('Starting Portfolio Value: {}'.format(cerebro.broker.getvalue()))

--- a/sample/strategy_sma_crossover.py
+++ b/sample/strategy_sma_crossover.py
@@ -72,7 +72,7 @@ if __name__ == '__main__':
         cerebro.setbroker(broker)
     else:
         data0 = DataFactory(dataname='AAPL', historical=True, fromdate=datetime(
-            2015, 1, 1), timeframe=bt.TimeFrame.Days)
+            2015, 1, 1), todate=datetime.today(), timeframe=bt.TimeFrame.Days)
     cerebro.adddata(data0)
 
     if not ALPACA_PAPER:


### PR DESCRIPTION
Without the todate param, it throws exception:

Traceback (most recent call last):
  File "/Users/xxx/.pyenv/versions/3.7.3/lib/python3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "/Users/xxx/.pyenv/versions/3.7.3/lib/python3.7/threading.py", line 865, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/xxx/.pyenv/versions/3.7.3/lib/python3.7/site-packages/alpaca_backtrader_api/alpacastore.py", line 414, in _t_candles
    pytz.timezone(NY).localize(dtend)
  File "/Users/xxx/.pyenv/versions/3.7.3/lib/python3.7/site-packages/pytz/tzinfo.py", line 317, in localize
    if dt.tzinfo is not None:
AttributeError: 'NoneType' object has no attribute 'tzinfo'