### PR TITLE
Fix minute backtests

### DIFF
--- a/alpaca_backtrader_api/alpacastore.py
+++ b/alpaca_backtrader_api/alpacastore.py
@@ -510,7 +510,7 @@ class AlpacaStore(with_metaclass(MetaSingleton, object)):
                     _from=self.iso_date(segment_start.isoformat()),
                     to=self.iso_date(segment_end.isoformat()))
                 # No result from the server, most likely error
-                if response.df.shape[0] == 0:
+                if response.df.shape[0] == 0 and cdl.shape[0] == 0:
                     raise Exception("received empty response")
                 temp = response.df
                 cdl = pd.concat([cdl, temp])

--- a/alpaca_backtrader_api/alpacastore.py
+++ b/alpaca_backtrader_api/alpacastore.py
@@ -502,7 +502,7 @@ class AlpacaStore(with_metaclass(MetaSingleton, object)):
             segment_start = dtbegin
             segment_end = segment_start + timedelta(weeks=2) if \
                 dtend - dtbegin >= timedelta(weeks=2) else dtend
-            while segment_end <= dtend:
+            while segment_end <= dtend and dtend not in cdl.index:
                 response = self.oapi.polygon.historic_agg_v2(
                     dataname,
                     compression,

--- a/alpaca_backtrader_api/alpacastore.py
+++ b/alpaca_backtrader_api/alpacastore.py
@@ -1,7 +1,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import os
 import collections
 from enum import Enum
 import traceback
@@ -24,6 +23,7 @@ from backtrader.metabase import MetaParams
 from backtrader.utils.py3 import queue, with_metaclass
 
 NY = 'America/New_York'
+
 
 # Extend the exceptions to support extra cases
 class AlpacaError(Exception):
@@ -88,6 +88,7 @@ class API(tradeapi.REST):
             return resp
 
         return None
+
 
 class Granularity(Enum):
     Daily = "day"

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,2 +1,3 @@
 backtrader==1.9.76.123
 alpaca-trade-api==0.49.1
+trading_calendars==1.11.8


### PR DESCRIPTION
when doing a minute backtest, we need to get data until the last known market opened minute.
this PR makes sure we don't try to get (non existing) data for "now" when market may be closed.