### PR TITLE
Enable trailing stop orders

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,3 @@
 backtrader==1.9.76.123
-alpaca-trade-api==0.49.1
+alpaca-trade-api==0.50.1
 trading_calendars==1.11.10


### PR DESCRIPTION
in v0.50.1 of alpaca-trade-api trailing stop orders were added,
this update enables this feature.