### PR TITLE
Made changes to explicitly add client order id

### DIFF
--- a/alpaca_backtrader_api/alpacabroker.py
+++ b/alpaca_backtrader_api/alpacabroker.py
@@ -266,6 +266,10 @@ class AlpacaBroker(with_metaclass(MetaAlpacaBroker, BrokerBase)):
 
     def _transmit(self, order):
         oref = order.ref
+        if order.info['client_order_id']:
+            client_order_id = order.info['client_order_id']
+        else:
+            client_order_id = None
         pref = getattr(order.parent, 'ref', oref)  # parent ref or self
         if order.transmit:
             if oref != pref:  # children order
@@ -277,12 +281,12 @@ class AlpacaBroker(with_metaclass(MetaAlpacaBroker, BrokerBase)):
                     self.orders[o.ref] = o  # write them down
 
                 self.brackets[pref] = [parent, stopside, takeside]
-                self.o.order_create(parent, stopside, takeside)
+                self.o.order_create(parent, stopside, takeside, client_order_id)
                 return takeside  # parent was already returned
 
             else:  # Parent order, which is not being transmitted
                 self.orders[order.ref] = order
-                return self.o.order_create(order)
+                return self.o.order_create(order, client_order_id)
 
         # Not transmitting
         self.opending[pref].append(order)

--- a/alpaca_backtrader_api/alpacastore.py
+++ b/alpaca_backtrader_api/alpacastore.py
@@ -759,7 +759,7 @@ class AlpacaStore(with_metaclass(MetaSingleton, object)):
 
             self._evt_acct.set()
 
-    def order_create(self, order, stopside=None, takeside=None, **kwargs):
+    def order_create(self, order, stopside=None, takeside=None, client_order_id=None, **kwargs):
         okwargs = dict()
         # different data feeds may set _name or _dataname so we cover both
         okwargs['symbol'] = order.data._name if order.data._name else \
@@ -786,6 +786,9 @@ class AlpacaStore(with_metaclass(MetaSingleton, object)):
 
         if stopside or takeside:
             okwargs['order_class'] = "bracket"
+
+        if client_order_id:
+            okwargs['client_order_id'] = client_order_id
 
         if order.exectype == bt.Order.StopTrail:
             if order.trailpercent and order.trailamount:


### PR DESCRIPTION
Changed _transmit in alpacabroker.py and order_create in alpacastore.py to explicitly add client_order_id.