### PR TITLE
Fix constants in all example code

### DIFF
--- a/sample/strategy_multiple_datas.py
+++ b/sample/strategy_multiple_datas.py
@@ -3,6 +3,9 @@ import backtrader as bt
 from datetime import datetime
 
 
+# Your credentials here
+ALPACA_API_KEY = "<key_id>"
+ALPACA_SECRET_KEY = "<secret_key>"
 """
 You have 3 options: 
  - backtest (IS_BACKTEST=True, IS_LIVE=False)
@@ -13,6 +16,8 @@ IS_BACKTEST = True
 IS_LIVE = False
 SYMBOL1 = 'AAPL'
 SYMBOL2 = 'GOOG'
+USE_POLYGON = False
+
 
 class SmaCross1(bt.Strategy):
     # list of parameters which are configurable for the strategy
@@ -76,7 +81,7 @@ if __name__ == '__main__':
     store = alpaca_backtrader_api.AlpacaStore(
         key_id=ALPACA_API_KEY,
         secret_key=ALPACA_SECRET_KEY,
-        paper=IS_LIVE,
+        paper=not IS_LIVE,
         usePolygon=USE_POLYGON
     )
 

--- a/sample/strategy_multiple_indicators.py
+++ b/sample/strategy_multiple_indicators.py
@@ -83,7 +83,7 @@ if __name__ == '__main__':
     store = alpaca_backtrader_api.AlpacaStore(
         key_id=ALPACA_API_KEY,
         secret_key=ALPACA_SECRET_KEY,
-        paper=IS_LIVE,
+        paper=not IS_LIVE,
         usePolygon=USE_POLYGON
     )
 

--- a/sample/strategy_readme_sample.py
+++ b/sample/strategy_readme_sample.py
@@ -6,9 +6,7 @@ from datetime import datetime
 # Your credentials here
 ALPACA_API_KEY = "<key_id>"
 ALPACA_SECRET_KEY = "<secret_key>"
-# change to True if you want to do live paper trading with Alpaca Broker.
-#  False will do a back test
-ALPACA_PAPER = False
+
 
 """
 You have 3 options: 
@@ -19,6 +17,7 @@ You have 3 options:
 IS_BACKTEST = False
 IS_LIVE = False
 symbol = "AAPL"
+USE_POLYGON = False
 
 
 class SmaCross(bt.SignalStrategy):
@@ -35,7 +34,7 @@ if __name__ == '__main__':
     store = alpaca_backtrader_api.AlpacaStore(
         key_id=ALPACA_API_KEY,
         secret_key=ALPACA_SECRET_KEY,
-        paper=IS_LIVE,
+        paper=not IS_LIVE,
         usePolygon=USE_POLYGON
     )
 

--- a/sample/strategy_sma_crossover.py
+++ b/sample/strategy_sma_crossover.py
@@ -5,9 +5,6 @@ from datetime import datetime
 # Your credentials here
 ALPACA_API_KEY = "<key_id>"
 ALPACA_SECRET_KEY = "<secret_key>"
-# change to True if you want to do live paper trading with Alpaca Broker.
-#  False will do a back test
-ALPACA_PAPER = False
 
 """
 You have 3 options: 
@@ -18,7 +15,7 @@ You have 3 options:
 IS_BACKTEST = False
 IS_LIVE = False
 symbol = "AA"
-
+USE_POLYGON = False
 
 
 class SmaCross1(bt.Strategy):
@@ -90,7 +87,7 @@ if __name__ == '__main__':
     store = alpaca_backtrader_api.AlpacaStore(
         key_id=ALPACA_API_KEY,
         secret_key=ALPACA_SECRET_KEY,
-        paper=IS_LIVE,
+        paper=not IS_LIVE,
         usePolygon=USE_POLYGON
     )
 


### PR DESCRIPTION
This is a cleaner solution for https://github.com/alpacahq/alpaca-backtrader-api/pull/118

credentials, USE_POLYGON, IS_LIVE were not initialized correctly in the example code