### PR TITLE
Update _loadtick in alpacadata.py

### DIFF
--- a/alpaca_backtrader_api/alpacadata.py
+++ b/alpaca_backtrader_api/alpacadata.py
@@ -387,7 +387,7 @@ class AlpacaData(with_metaclass(MetaAlpacaData, DataBase)):
                     return False
 
     def _load_tick(self, msg):
-        dtobj = datetime.utcfromtimestamp(int(msg['time']))
+        dtobj = datetime.utcfromtimestamp(msg['time'])
         dt = date2num(dtobj)
         if dt <= self.lines.datetime[-1]:
             return False  # time already seen


### PR DESCRIPTION
Type casting msg['time'] to int in _loadtick causes the timestamp to lose the millisecond attribute and appearing as resampled seconds inside backtrader strategy data.