### PR TITLE
replace trading_calendars with exchange_calendars

### DIFF
--- a/alpaca_backtrader_api/alpacastore.py
+++ b/alpaca_backtrader_api/alpacastore.py
@@ -9,7 +9,7 @@ import traceback
 from datetime import datetime, timedelta, time as dtime
 from dateutil.parser import parse as date_parse
 import time as _time
-import trading_calendars
+import exchange_calendars
 import threading
 import asyncio
 
@@ -442,7 +442,7 @@ class AlpacaStore(with_metaclass(MetaSingleton, object)):
         else:
             dtend = pd.Timestamp(pytz.timezone('UTC').localize(dtend))
         if granularity == Granularity.Minute:
-            calendar = trading_calendars.get_calendar(name='NYSE')
+            calendar = exchange_calendars.get_calendar(name='NYSE')
             while not calendar.is_open_on_minute(dtend):
                 dtend = dtend.replace(hour=15,
                                       minute=59,

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
 backtrader==1.9.76.123
 alpaca-trade-api==1.2.2
-trading_calendars==2.1.1
+exchange_calendars==3.2
 


### PR DESCRIPTION
fix for https://github.com/alpacahq/alpaca-backtrader-api/issues/176

[trading_calendars](https://github.com/quantopian/trading_calendars) is [broken](https://github.com/quantopian/trading_calendars/issues/224) and [unmaintained](https://github.com/quantopian/trading_calendars/blob/master/README.md).
[exchange_calendars](https://github.com/gerrymanoim/exchange_calendars) is a maintained fork that's [recommended by trading_calendars](https://github.com/quantopian/trading_calendars/blob/master/README.md) and has [fixed](https://github.com/gerrymanoim/exchange_calendars/pull/41) this issue.
This PR changes from trading_calendars to exchange_calendars to resolve https://github.com/alpacahq/alpaca-backtrader-api/issues/176.