### PR TITLE
Fixing alpaca dependencies with backtrader and main trading api

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,4 +4,4 @@ exchange-calendars==3.5
 matplotlib==3.5.1
 msgpack==1.0.3
 numpy==1.22.0
-pandas==1.3.2
+pandas==1.3.5

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 backtrader==1.9.76.123
 alpaca-trade-api==1.4.3
-exchange-calendars==3.4
+exchange-calendars==3.5
 matplotlib==2.2.5
 msgpack==1.0.2
 numpy==1.21.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 backtrader==1.9.76.123
 alpaca-trade-api==1.4.3
 exchange-calendars==3.5
-matplotlib==2.2.5
+matplotlib==3.5.1
 msgpack==1.0.2
 numpy==1.21.2
 pandas==1.3.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,6 +2,6 @@ backtrader==1.9.76.123
 alpaca-trade-api==1.4.3
 exchange-calendars==3.5
 matplotlib==3.5.1
-msgpack==1.0.3
+msgpack==1.0.2
 numpy==1.22.0
 pandas==1.3.5

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 backtrader==1.9.76.123
 alpaca-trade-api==1.4.3
 exchange-calendars==3.5
-matplotlib==3.5.1
+matplotlib==3.2.2
 msgpack==1.0.2
 numpy==1.22.0
 pandas==1.3.5

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,6 +2,6 @@ backtrader==1.9.76.123
 alpaca-trade-api==1.4.3
 exchange-calendars==3.5
 matplotlib==3.5.1
-msgpack==1.0.2
+msgpack==1.0.3
 numpy==1.21.2
 pandas==1.3.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,5 +3,5 @@ alpaca-trade-api==1.4.3
 exchange-calendars==3.5
 matplotlib==3.5.1
 msgpack==1.0.3
-numpy==1.21.2
+numpy==1.22.0
 pandas==1.3.2


### PR DESCRIPTION
Pinned a few dependency versions differently to make the package installable and examples are basic README example works again